### PR TITLE
Remove w3schools Namespaces

### DIFF
--- a/README
+++ b/README
@@ -2,9 +2,9 @@ This project contains a reference to configuration files used on Magento e-comme
 
 To use your XSD reference, define your "config" tag as: 
 
-<config xmlns="http://www.w3schools.com"
+<config xmlns="http://magento.com/schema/module/config"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="localhost ../xsd/etc_config.xsd">
+xsi:schemaLocation="xsd/etc_config.xsd">
 </config>
 
 Where you may define the schemaLocation must be applied as "host path/to/the/file.xsd"

--- a/xml/etc_config.xml
+++ b/xml/etc_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<config xmlns="http://www.w3schools.com"
+<config xmlns="http://magento.com/schema/module/config"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="localhost ../xsd/etc_config.xsd">
+xsi:schemaLocation="../xsd/etc_config.xsd">
     <modules>
         <SchemaName_ModuleName>
             <depends></depends>

--- a/xml/theme_layout_local.xml
+++ b/xml/theme_layout_local.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<layout xmlns="http://www.w3schools.com"
+<layout xmlns="http://magento.com/schema/theme/layout"
 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:schemaLocation="localhost ../xsd/theme_layout_local.xsd">
+xsi:schemaLocation=" ../xsd/theme_layout_local.xsd">
     <default>
         <remove name="right.poll"></remove>
         

--- a/xsd/etc_config.xsd
+++ b/xsd/etc_config.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="http://www.w3schools.com"
-           xmlns="http://www.w3schools.com"
+           targetNamespace="http://magento.com/schema/module/config"
            elementFormDefault="qualified">
     <xs:element name="config" maxOccurs="1">
         <xs:annotation>

--- a/xsd/theme_layout_local.xsd
+++ b/xsd/theme_layout_local.xsd
@@ -1,7 +1,6 @@
 <?xml version="1.0"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-targetNamespace="http://www.w3schools.com"
-xmlns="http://www.w3schools.com"
+targetNamespace="http://magento.com/schema/theme/layout"
 elementFormDefault="qualified">
     <xs:element name="layout">
         <xs:annotation>


### PR DESCRIPTION
Namespaces shouldn't be w3schools (an unrelated website).  They should instead be unique strings for the specific XML schema.  In this PR I've removed them and replaced them with Magento.com non-existant URLs
